### PR TITLE
Implement noiseless likelihood for linear chirp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pdf
+*__pycache__
+*egg*

--- a/src/sfts/kernels.py
+++ b/src/sfts/kernels.py
@@ -1,23 +1,17 @@
 import jax.numpy as jnp
 from jax.scipy import special
 
-def discrete_dirichlet(k, N):
+def dirichlet_kernel(f, T_sft):
     """
-    Dirichlet kernel using discrete variables.
+    Dirichlet kernel.
     See Appendix of Tenorio & Gerosa (2025).
-
-    Parameters
-    ----------
-    k:
-        Frequency in ``index'' units (i.e. `floor(f / Tsft)`).
-    N:
-        Number of time-domain samples
     """
-    return N * jnp.exp(1j * jnp.pi * k) * jnp.sinc(k)
+    return T_sft * jnp.exp(1j * jnp.pi * f * T_sft) * jnp.sinc(f * T_sft)
 
 def fresnel_kernel(f_0, f_1, T_sft):
     """
     Fresnel kernel.
+    See Eq. (29) of Tenorio & Gerosa (2025).
     """
     quot = f_0 / f_1
     factor = jnp.sqrt(2 * f_1)


### PR DESCRIPTION
Closes #3 

Implements the "full likelihood" computation for a linear chirp:
```
-0.5 * <d-h|d-h>
```
Signal parameters (A, f_0, f_1, phi_0) peak at the injection parameters.

Also, unify Kernel conventions as otherwise we are looking for trouble. 